### PR TITLE
Add Windows Support for tinker()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0"
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
+        "symfony/process": "^5.0"
     },
     "autoload": {
         "files": [

--- a/src/helper.php
+++ b/src/helper.php
@@ -58,9 +58,7 @@ if (! function_exists('tinker')) {
                 throw new ProcessFailedException($process);
             }
 
-            echo $process->getOutput();
         } catch (ProcessFailedException $exception) {
-            echo $exception->getMessage();
             Log::error($exception->getMessage());
         }
     }

--- a/src/helper.php
+++ b/src/helper.php
@@ -41,7 +41,7 @@ if (! function_exists('tinker')) {
         // For MacOS
         $command = 'open "tinkerwell://?cwd='.base64_encode(base_path()).'&scope='.base64_encode(serialize($namedParameters)).'"';
 
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if (windows_os()) {
             $logPath = base_path() . '\\storage\\logs\\tinkerwell-' . date("Y-m-d") . '.log';
 
             // For Windows || ATTENTION ... I added a ^ before the & to escape it.

--- a/src/helper.php
+++ b/src/helper.php
@@ -3,6 +3,9 @@
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
 if (! function_exists('tinker')) {
     function tinker(...$args)
     {
@@ -33,6 +36,32 @@ if (! function_exists('tinker')) {
             ->combine($args)
             ->all();
 
-        exec('open "tinkerwell://?cwd='.base64_encode(base_path()).'&scope='.base64_encode(serialize($namedParameters)).'"');
+        //exec('open "tinkerwell://?cwd='.base64_encode(base_path()).'&scope='.base64_encode(serialize($namedParameters)).'"');
+
+        // For MacOS
+        $command = 'open "tinkerwell://?cwd='.base64_encode(base_path()).'&scope='.base64_encode(serialize($namedParameters)).'"';
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $logPath = base_path() . '\\storage\\logs\\tinkerwell-' . date("Y-m-d") . '.log';
+
+            // For Windows || ATTENTION ... I added a ^ before the & to escape it.
+            // If base64 encoded string of $namedParameters lenght is too long (I don't know what the limit is) the execution will fail
+            $command ='start tinkerwell://?cwd='.base64_encode(base_path()) .'^&scope='.base64_encode(serialize($namedParameters)) . ' >> ' . $logPath . ' 2>&1';
+        }
+
+        $process = new Process($command);
+
+        try {
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            echo $process->getOutput();
+        } catch (ProcessFailedException $exception) {
+            echo $exception->getMessage();
+            Log::error($exception->getMessage());
+        }
     }
 }


### PR DESCRIPTION
I could make it work, that the app is opened in Windows.
 The only thing that doesn't work, for now, is that the variables are not populated.

I hope my pull request helps to bring this feature as fast as possible to Windows... because it's awesome!!!